### PR TITLE
Functional @ionic build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# API Key Parsing
+*.do_not_commit*
+
 # Created by https://www.gitignore.io/api/ionic3,angular,visualstudiocode
 
 ### Angular ###

--- a/make_ionic.sh
+++ b/make_ionic.sh
@@ -43,6 +43,7 @@ detect_os() {
 
 install_depend() {
   package=$1
+
   printf "Detecting OS Package Manager: "
   packman="$(detect_os)"
   if $(isinstalled $packman); then

--- a/make_ionic.sh
+++ b/make_ionic.sh
@@ -13,8 +13,13 @@
 API_FILE="keys.do_not_commit.json"
 API_KEY="google_maps_api"
 MAPS_VERSION="4.9.1"
-
-usage() { printf "Usage: $0 \n\t-i input_api.json\tDefault=$API_FILE\n\t-m maps_api_version\tDefault=$MAPS_VERSION\n" 1>&2; exit 1; }
+PARSE_ONLY=false
+usage() { 
+  printf "Usage: $0 \n\t-i input_api.json\tDefault=$API_FILE\n" 1>&2
+  printf "\t-m maps_api_version\tDefault=$MAPS_VERSION\n" 1>&2
+  printf "\t-p Parse key only\tDefault=$PARSE_ONLY\n" 1>&2
+  exit 1
+}
 
 install_ionic() {
   i_key=$1
@@ -69,13 +74,16 @@ parse_key_file() {
 }
 
 ### Parse CLI Options  ###
-while getopts ":hi:" o; do
+while getopts ":hi:p" o; do
   case "${o}" in
     h)
       usage 
       ;;
     i)
       API_FILE=${OPTARG}
+      ;;
+    p)
+      PARSE_ONLY=true
       ;;
     *)
       usage
@@ -92,6 +100,11 @@ fi
 
 echo "Parsing API Credentials: $API_FILE"
 api_key="$(parse_key_file $API_FILE $API_KEY)"
+
+if $PARSE_ONLY; then
+  echo $api_key
+  exit 0
+fi
 
 # Confirm receipt of api_file
 if [[ -z $api_key ]]; then

--- a/make_ionic.sh
+++ b/make_ionic.sh
@@ -37,6 +37,7 @@ detect_os() {
     *)
       echo "Error: Failed to detect OS!"
       exit 1
+      ;;
   esac
   echo $PM
 }

--- a/make_ionic.sh
+++ b/make_ionic.sh
@@ -14,17 +14,27 @@ API_FILE="keys.do_not_commit.json"
 API_KEY="google_maps_api"
 MAPS_VERSION="4.9.1"
 
-usage() { echo "Usage: $0 [-i <input api.json for parsing>]" 1>&2; exit 1; }
+usage() { printf "Usage: $0 \n\t-i input_api.json\tDefault=$API_FILE\n\t-m maps_api_version\tDefault=$MAPS_VERSION\n" 1>&2; exit 1; }
 
 install_ionic() {
+  i_key=$1
+  maps_v=$MAPS_VERSION
+
+  depends='npm'
+  #printf "Testing dependency: $depends "
+  if ! $(isinstalled $depends); then
+    echo "FAIL"
+    echo "Error: Dependency not met: $depends"
+    exit 1
+  fi
 
   CMD="npm install @ionic-native/core @ionic-native/google-maps@${maps_v}"
-  CMD="ionic cordova plugin add cordova-plugin-googlemaps --variable API_KEY_FOR_ANDROID=\"${api_key}\" --variable API_KEY_FOR_IOS=\"${api_key}\""
-
+  eval $CMD
+  CMD="ionic cordova plugin add cordova-plugin-googlemaps --variable API_KEY_FOR_ANDROID=\"$i_key\" --variable API_KEY_FOR_IOS=\"$i_key\""
+  eval $CMD
 }
 
 isfile() {
-  echo $1
   if [[ -f $1 ]]; then
     return 0 
   else
@@ -33,7 +43,6 @@ isfile() {
 }
 
 isinstalled() {
-  echo "Checking installed command: $1"
   if [ -x "$(command -v $1)" ]; then
     return 0
   else
@@ -46,14 +55,17 @@ parse_key_file() {
   p_key=$2
 
   depends='jq'
-  echo "Checking dependency: $depends" 
-  if isinstalled $depends; then
+  #printf "Testing dependency: $depends "
+  if $(isinstalled $depends); then
+    #echo "OK"
     CMD="jq -r '.[].${p_key}' ${p_file}"
-    echo "Running parse cmd: $CMD"
-    eval $CMD
   else
+    echo "FAIL"
     echo "Error: Dependency not met: $depends"
+    exit 1
   fi
+
+  eval $CMD
 }
 
 ### Parse CLI Options  ###
@@ -73,17 +85,19 @@ done
 shift $((OPTIND-1))
 
 # Confirm api_file exists
-if isfile $API_FILE; then
-  echo "Parsing API Credentials: $API_FILE"
-  api_key="$(parse_key_file $API_FILE $API_KEY)"
-  # Confirm receipt of api_file
-  if [[ -z $api_key ]]; then
-    echo "Error Parsing API Credentials: $API_FILE"
-    usage
-  fi
-else
-  echo "Error: Infile not found: $API_FILE"
+if ! $(isfile $API_FILE); then
+  echo "Error: Infile not found: $API_FILE\n"
   usage
 fi
 
-echo $api_key
+echo "Parsing API Credentials: $API_FILE"
+api_key="$(parse_key_file $API_FILE $API_KEY)"
+
+# Confirm receipt of api_file
+if [[ -z $api_key ]]; then
+  echo "Error Parsing API Credentials: $API_FILE"
+  usage
+fi
+
+echo "API Key: $api_key"
+install_ionic "$api_key"

--- a/make_ionic.sh
+++ b/make_ionic.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# This script attempts to install/activate Ionic 3 environment in this repo: 
+# 
+# https://github.com/ionic-team/ionic-native-google-maps:
+#
+# """
+# @ionic-native/google-maps plugin is a wrapper plugin for cordova-plugin-googlemaps for Ionic framework.
+#
+# Ionic Native wraps plugin callbacks in a Promise or Observable, providing a common interface for all plugins
+# and making it easy to use plugins with Angular change detection. 
+# """
+
+API_FILE="keys.do_not_commit.json"
+API_KEY="google_maps_api"
+MAPS_VERSION="4.9.1"
+
+usage() { echo "Usage: $0 [-i <input api.json for parsing>]" 1>&2; exit 1; }
+
+install_ionic() {
+
+  CMD="npm install @ionic-native/core @ionic-native/google-maps@${maps_v}"
+  CMD="ionic cordova plugin add cordova-plugin-googlemaps --variable API_KEY_FOR_ANDROID=\"${api_key}\" --variable API_KEY_FOR_IOS=\"${api_key}\""
+
+}
+
+isfile() {
+  echo $1
+  if [[ -f $1 ]]; then
+    return 0 
+  else
+    return 1
+  fi
+}
+
+isinstalled() {
+  echo "Checking installed command: $1"
+  if [ -x "$(command -v $1)" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+parse_key_file() {
+  p_file=$1
+  p_key=$2
+
+  depends='jq'
+  echo "Checking dependency: $depends" 
+  if isinstalled $depends; then
+    CMD="jq -r '.[].${p_key}' ${p_file}"
+    echo "Running parse cmd: $CMD"
+    eval $CMD
+  else
+    echo "Error: Dependency not met: $depends"
+  fi
+}
+
+### Parse CLI Options  ###
+while getopts ":hi:" o; do
+  case "${o}" in
+    h)
+      usage 
+      ;;
+    i)
+      API_FILE=${OPTARG}
+      ;;
+    *)
+      usage
+    ;;
+  esac
+done
+shift $((OPTIND-1))
+
+# Confirm api_file exists
+if isfile $API_FILE; then
+  echo "Parsing API Credentials: $API_FILE"
+  api_key="$(parse_key_file $API_FILE $API_KEY)"
+  # Confirm receipt of api_file
+  if [[ -z $api_key ]]; then
+    echo "Error Parsing API Credentials: $API_FILE"
+    usage
+  fi
+else
+  echo "Error: Infile not found: $API_FILE"
+  usage
+fi
+
+echo $api_key

--- a/make_ionic.sh
+++ b/make_ionic.sh
@@ -14,6 +14,7 @@ API_FILE="keys.do_not_commit.json"
 API_KEY="google_maps_api"
 MAPS_VERSION="latest"
 PARSE_ONLY=false
+
 usage() { 
   printf "Usage: $0 \n\t-i input_api.json\tDefault=$API_FILE\n" 1>&2
   printf "\t-m maps_api_version\tDefault=$MAPS_VERSION\n" 1>&2

--- a/make_ionic.sh
+++ b/make_ionic.sh
@@ -74,9 +74,11 @@ install_ionic() {
       exit 1
     fi
   fi
-
+  
+  echo "Installing ionic:"
   CMD="npm install --save @ionic-native/core @ionic-native/google-maps@${maps_v}"
   eval $CMD
+  echo "Initiating plugin:"
   CMD="ionic cordova plugin add cordova-plugin-googlemaps --variable API_KEY_FOR_ANDROID=\"$i_key\" --variable API_KEY_FOR_IOS=\"$i_key\""
   eval $CMD
 }

--- a/make_ionic.sh
+++ b/make_ionic.sh
@@ -76,7 +76,9 @@ install_ionic() {
   fi
   
   echo "Installing ionic:"
-  CMD="npm install --save @ionic-native/core @ionic-native/google-maps@${maps_v}"
+  CMD="npm install -g ionic cordova"
+  eval $CMD
+  CMD="npm install @ionic-native/core @ionic-native/google-maps@${maps_v}"
   eval $CMD
   echo "Initiating plugin:"
   CMD="ionic cordova plugin add cordova-plugin-googlemaps --variable API_KEY_FOR_ANDROID=\"$i_key\" --variable API_KEY_FOR_IOS=\"$i_key\""


### PR DESCRIPTION
Execute: 
[make_ionic.sh](make_ionic.sh) to initiate ionic activation in this environment. 

Depends:
MapsAPI json file like (default file to parse: `key.do_not_commit.json`):

```json
[{
  "google_maps_api": "YOUR_KEY_HERE"
}]
```

Notes:

Tested on MacOS using brew package manager
Theoretical functionality in Linux(Debian/RPM) OS environments but NOT-tested as of this time.